### PR TITLE
Add support for Basilisk

### DIFF
--- a/src/install.rdf
+++ b/src/install.rdf
@@ -308,7 +308,7 @@
 		<em:targetApplication><!-- Waterfox -->
 			<Description>
 				<em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-				<em:minVersion>56.0</em:minVersion>
+				<em:minVersion>52.0</em:minVersion>
 				<em:maxVersion>56.*</em:maxVersion>
 			</Description>
 		</em:targetApplication>


### PR DESCRIPTION
Basilisk uses a version number of 52.